### PR TITLE
sane connection pool defaults + engine options

### DIFF
--- a/docs/engines.rst
+++ b/docs/engines.rst
@@ -22,3 +22,10 @@ following engines have dedicated support for the following insert modes:
 
 Engines not listed above will default to using multirow inserts if supported,
 falling back to single row inserts as a last resort.
+
+Engine customization
+####################
+
+engine_params: Optional dict of parameter that get destructured as keyword arguments for create_engine call in the engine. Allows customization of engine connection pool and such.
+
+For example, to set engine to use a connection pool size of one, pass engine_params = {"pool_size": 1}

--- a/sqltask/base/engine.py
+++ b/sqltask/base/engine.py
@@ -12,18 +12,19 @@ class EngineContext:
     def __init__(self,
                  name: str,
                  url: str,
-                 metadata_kwargs: Optional[Dict[str, Any]] = None,
+                 engine_params: Optional[Dict[str, Any]] = None,
+                 metadata_params: Optional[Dict[str, Any]] = None,
                  ):
         self.name = name
-        self.engine = create_engine(url)
+        self.engine = create_engine(url, **engine_params)
         self.engine_spec = get_engine_spec(self.engine.name)
         url_params = self.engine_spec.get_url_params(self.engine.url)
         self.database, self.schema = url_params
-        self.metadata_kwargs = metadata_kwargs or {}
+        self.metadata_params = metadata_params or {}
         self.metadata = MetaData(
             bind=self.engine,
             schema=url_params.schema,
-            **self.metadata_kwargs,
+            **self.metadata_params,
         )
         if url_params.database and url_params.schema:
             url_str = url_params.database + "/" + url_params.schema


### PR DESCRIPTION
- Add sensible default size to connection pool (create_engine in sqlalchemy defaults to size 5, a more sensible default is 1)
- add parametrization of engine upon initialization (to allow customization of the engine spec)